### PR TITLE
RE:RE: Issue #11

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -6,6 +6,7 @@
     <dependency org="org.jruby" name="jruby-complete" rev="1.6.2" />
     <dependency org="junit" name="junit" rev="4.8.2" />
     <dependency org="org.jboss.apiviz" name="apiviz" rev="1.3.1.GA" />
+    <dependency org="com.google.guava" name="guava" rev="r08" />
   </dependencies>
 </ivy-module>
 

--- a/src/net/lightstone/Server.java
+++ b/src/net/lightstone/Server.java
@@ -3,7 +3,6 @@ package net.lightstone;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -26,6 +25,8 @@ import org.jboss.netty.channel.group.ChannelGroup;
 import org.jboss.netty.channel.group.DefaultChannelGroup;
 import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
 
+import com.google.common.collect.MapMaker;
+
 /**
  * The core class of the Lightstone server.
  * @author Graham Edgecombe
@@ -41,7 +42,7 @@ public final class Server {
 	/**
 	 * A map of servers.
 	 */
-	private static Map<String, Server> servers = new HashMap<String, Server>();
+	private static Map<String, Server> servers = new MapMaker().weakValues().makeMap();
 
 	/**
 	 * Creates a new server on TCP port 25565 and starts listening for

--- a/src/net/lightstone/Server.java
+++ b/src/net/lightstone/Server.java
@@ -3,6 +3,8 @@ package net.lightstone;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
@@ -27,6 +29,7 @@ import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
 /**
  * The core class of the Lightstone server.
  * @author Graham Edgecombe
+ * @author Joe Pritzel
  */
 public final class Server {
 
@@ -34,6 +37,11 @@ public final class Server {
 	 * The logger for this class.
 	 */
 	private static final Logger logger = Logger.getLogger(Server.class.getName());
+	
+	/**
+	 * A map of servers.
+	 */
+	private static Map<String, Server> servers = new HashMap<String, Server>();
 
 	/**
 	 * Creates a new server on TCP port 25565 and starts listening for
@@ -42,7 +50,8 @@ public final class Server {
 	 */
 	public static void main(String[] args) {
 		try {
-			Server server = new Server();
+			Server server = new Server("main");
+			servers.put(server.getName(), server);
 			server.bind(new InetSocketAddress(25565));
 			server.start();
 		} catch (Throwable t) {
@@ -84,7 +93,7 @@ public final class Server {
 	/**
 	 * The world this server is managing.
 	 */
-	private final World world = new World(new McRegionChunkIoService(), new ForestWorldGenerator());
+	private final World world;
 
 	/**
 	 * Whether the server should automatically save chunks, e.g. at shutdown.
@@ -92,9 +101,17 @@ public final class Server {
 	private boolean saveEnabled = true;	// TODO: Does this belong in a different class e.g. the chunk IO service or the chunk manager?
 
 	/**
-	 * Creates a new server.
+	 * The name of this server.
 	 */
-	public Server() {
+	private final String name;
+
+	/**
+	 * Creates a new server.
+	 * @param string 
+	 */
+	public Server(String name) {
+		this.name = name;
+		world = new World(this.name, new McRegionChunkIoService(this.name), new ForestWorldGenerator());
 		logger.info("Starting Lightstone...");
 		init();
 	}
@@ -206,6 +223,14 @@ public final class Server {
 				logger.info("Finished!");
 			}
 		}
+	}
+	
+	public static Server getServer(String name) {
+		return servers.get(name);
+	}
+
+	public String getName() {
+		return name;
 	}
 
 }

--- a/src/net/lightstone/cache/ConcurrentLRUMap.java
+++ b/src/net/lightstone/cache/ConcurrentLRUMap.java
@@ -1,0 +1,241 @@
+package net.lightstone.cache;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * This is a generic implementation of a thread-safe LRU map.
+ * 
+ * @author Joe Pritzel
+ * 
+ * @param <K>
+ * @param <V>
+ */
+public class ConcurrentLRUMap<K, V> extends AbstractMap<K, V> {
+
+	private static final float DEFAULT_LOAD_FACTOR = 0.75f;
+	private static final int DEFAULT_MAX_SIZE = 100;
+
+	private AtomicInteger maxSize = new AtomicInteger(0);;
+	private final float loadFactor;
+
+	private final Map<K, Value<V>> map;
+
+	public ConcurrentLRUMap() {
+		this(DEFAULT_MAX_SIZE, DEFAULT_LOAD_FACTOR);
+	}
+
+	public ConcurrentLRUMap(final int maxSize) {
+		this(maxSize, DEFAULT_LOAD_FACTOR);
+	}
+
+	public ConcurrentLRUMap(final int maxSize, final float loadFactor) {
+		this.maxSize.set(maxSize);
+		this.loadFactor = loadFactor;
+		map = new ConcurrentHashMap<K, Value<V>>(this.maxSize.get(),
+				this.loadFactor);
+	}
+
+	/**
+	 * @return The max size for the LRUMap
+	 */
+	protected int getMaxSize() {
+		return maxSize.get();
+	}
+
+	/**
+	 * Increases the max size for the LRUMap by one.
+	 * @return The new max size
+	 */
+	protected int incrementMaxSize() {
+		return maxSize.incrementAndGet();
+	}
+
+	/**
+	 * Decreases the max size for the LRUMap by one.
+	 * @return
+	 */
+	protected int decrementMaxSize() {
+		return maxSize.decrementAndGet();
+	}
+
+	/**
+	 * @return The LRU entry.
+	 */
+	private Map.Entry<K, Value<V>> getLRU() {
+		Map.Entry<K, Value<V>> e1 = null;
+		long t = Long.MAX_VALUE;
+		final Set<Map.Entry<K, Value<V>>> m = map.entrySet();
+		for (Map.Entry<K, Value<V>> e : m) {
+			if (e.getValue().getTime() <= t) {
+				e1 = e;
+				t = e.getValue().getTime();
+			}
+		}
+		return e1;
+	}
+
+	/**
+	 * Removes entry if shouldRemove the key is non-null, and shouldRemove returns true.
+	 */
+	protected boolean tryRemove(K k, V v) {
+		if (k != null && shouldRemove(k, v)) {
+			map.remove(k);
+			dispose(k, v);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * This method is called when an entry is removed due to it being the least
+	 * recently used.
+	 * 
+	 * @param k
+	 * @param v
+	 */
+	protected void dispose(K k, V v) {
+	}
+	
+	/**
+	 * This method is called from the tryRemove method.
+	 * @param key
+	 * @param value
+	 * @return
+	 */
+	protected boolean shouldRemove(K key, V value) {
+		return true;
+	}
+
+	/**
+	 * This method is called when the size of the LRU map is
+	 * greater-than-or-equal-to the max size, and a new entry is being added.
+	 * 
+	 * @return If the LRU entry should be removed.
+	 */
+	protected boolean shouldRemoveLRU(K key, V value) {
+		return true;
+	}
+
+	@Override
+	public void clear() {
+		map.clear();
+	}
+
+	@Override
+	public boolean containsKey(Object arg0) {
+		return map.containsKey(arg0);
+	}
+
+	@Override
+	public boolean containsValue(Object arg0) {
+		for (Value<V> v : map.values()) {
+			if (v.get().equals(arg0)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public Set<Map.Entry<K, V>> entrySet() {
+		final Map<K, V> m = new HashMap<K, V>();
+		for (Map.Entry<K, Value<V>> e : map.entrySet()) {
+			m.put(e.getKey(), e.getValue().get());
+		}
+		return m.entrySet();
+	}
+
+	@Override
+	public V get(Object arg0) {
+		Value<V> v1 = map.get(arg0);
+		if (v1 != null)
+			return v1.get();
+		return null;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return map.isEmpty();
+	}
+
+	@Override
+	public Set<K> keySet() {
+		return map.keySet();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public V put(Object arg0, Object arg1) {
+		final Value<V> val = map.put((K) arg0, new Value<V>((V) arg1));
+		if (map.size() > maxSize.get()) {
+			Map.Entry<K, Value<V>> e1 = getLRU();
+			if (shouldRemoveLRU(e1.getKey(), e1.getValue().get())) {
+				tryRemove(e1.getKey(), e1.getValue().get());
+			}
+		}
+		if (val != null)
+			return val.get();
+		return null;
+	}
+
+	@Override
+	public void putAll(Map<? extends K, ? extends V> arg0) {
+		for (Entry<? extends K, ? extends V> e : arg0.entrySet()) {
+			put(e.getKey(), e.getValue());
+		}
+	}
+
+	@Override
+	public V remove(Object arg0) {
+		return map.remove(arg0).get();
+	}
+
+	@Override
+	public int size() {
+		return map.size();
+	}
+
+	@Override
+	public Collection<V> values() {
+		final Collection<V> c = new HashSet<V>();
+		for (Map.Entry<K, Value<V>> e : map.entrySet()) {
+			c.add(e.getValue().get());
+		}
+		return c;
+	}
+
+	private class Value<V1> {
+
+		private AtomicReference<V1> v;
+		private AtomicLong t;
+
+		public Value(V1 v) {
+			this(v, System.nanoTime());
+		}
+
+		public Value(V1 v, long t) {
+			this.v = new AtomicReference<V1>(v);
+			this.t = new AtomicLong(t);
+		}
+
+		public V1 get() {
+			t.set(System.nanoTime());
+			return v.get();
+		}
+
+		public long getTime() {
+			return t.get();
+		}
+
+	}
+
+}

--- a/src/net/lightstone/cache/package-info.java
+++ b/src/net/lightstone/cache/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Contains cache implementations.
+ */
+package net.lightstone.cache;
+

--- a/src/net/lightstone/io/ChunkIoService.java
+++ b/src/net/lightstone/io/ChunkIoService.java
@@ -31,5 +31,8 @@ public interface ChunkIoService {
 	 */
 	public void write(int x, int z, Chunk chunk) throws IOException;
 
+	public void setWorldName(String name);
+	public String getWorldName();
+
 }
 

--- a/src/net/lightstone/io/McRegionChunkIoService.java
+++ b/src/net/lightstone/io/McRegionChunkIoService.java
@@ -48,15 +48,18 @@ public final class McRegionChunkIoService implements ChunkIoService {
 	 * The region file cache.
 	 */
 	private RegionFileCache cache = new RegionFileCache();
+	
+	private String name;
 
 	// TODO: consider the session.lock file
 
 	public McRegionChunkIoService() {
-		this(new File("world"));
+		this("world");
 	}
 
-	public McRegionChunkIoService(File dir) {
-		this.dir = dir;
+	public McRegionChunkIoService(String name2) {
+		this.name = name2;
+		this.dir = new File(name);
 	}
 
 	@Override
@@ -188,6 +191,17 @@ public final class McRegionChunkIoService implements ChunkIoService {
 	private ListTag<CompoundTag> chunkTileEntitiesToTag(Chunk chunk) {
 		List<CompoundTag> entityTags = new ArrayList<CompoundTag>();
 		return new ListTag<CompoundTag>("TileEntities", CompoundTag.class, entityTags);
+	}
+	
+	@Override
+	public String getWorldName() {
+		return name;
+	}
+
+	@Override
+	public void setWorldName(String name) {
+		this.name = name;
+		dir = new File(this.name);
 	}
 
 }

--- a/src/net/lightstone/model/Player.java
+++ b/src/net/lightstone/model/Player.java
@@ -194,5 +194,9 @@ public final class Player extends Mob {
 		return crouching;
 	}
 
+	public Set<Chunk.Key> getKnownChunks() {
+		return knownChunks;
+	}
+
 }
 

--- a/src/net/lightstone/world/World.java
+++ b/src/net/lightstone/world/World.java
@@ -45,10 +45,12 @@ public class World {
 	/**
 	 * Creates a new world with the specified chunk I/O service and world
 	 * generator.
+	 * @param name 
 	 * @param service The chunk I/O service.
 	 * @param generator The world generator.
 	 */
-	public World(ChunkIoService service, WorldGenerator generator) {
+	public World(String name, ChunkIoService service, WorldGenerator generator) {
+		service.setWorldName(name);
 		chunks = new ChunkManager(service, generator);
 	}
 


### PR DESCRIPTION
The last one didn't take for whatever reason, so I've re-forked and just committed the changes directly related to issue #11.

"Implemented a concurrent LRU map, and have greatly improved on the 'memory leak' issue.

The only 'memory leak' issue left is easily resolvable; see TODOs in the ChunkManager class.

Anyway, there isn't really a way to limit the amount of chunks loaded, without potentially causing tons of I/O, in a manner that doesn't require some form of cleanup.

So, currently the number of chunks in memory is the most players online times the number of chunks they're able to see at once. Before it was the number of chunks all the clients have ever seen. Once the cleanup is implemented, it will essentially be just the chunks that are actually being used." - Issue #25
